### PR TITLE
feat: 게시글 api 추가(인증, 권한 x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.1",
         "@nestjs/typeorm": "^11.0.0",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2",
@@ -4514,6 +4515,12 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
       "license": "MIT"
     },
     "node_modules/class-validator": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.1",
     "@nestjs/typeorm": "^11.0.0",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,8 @@ import { AppService } from "./app.service";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { UsersModule } from "./users/users.module";
+import { PostsModule } from "./posts/posts.module";
+import { PostCommentsModule } from "./post-comments/post-comments.module";
 
 @Module({
   imports: [
@@ -27,6 +29,8 @@ import { UsersModule } from "./users/users.module";
       },
     }),
     UsersModule,
+    PostsModule,
+    PostCommentsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/entities/base-time.entity.ts
+++ b/src/common/entities/base-time.entity.ts
@@ -1,0 +1,9 @@
+import { CreateDateColumn, UpdateDateColumn } from "typeorm";
+
+export abstract class BaseTimeEntity {
+  @CreateDateColumn({ type: "timestamptz" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: "timestamptz" })
+  updatedAt: Date;
+}

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -1,0 +1,1 @@
+export * from "./isNotBlank";

--- a/src/common/validators/isNotBlank.ts
+++ b/src/common/validators/isNotBlank.ts
@@ -1,0 +1,20 @@
+import { registerDecorator, ValidationArguments, ValidationOptions } from "class-validator";
+
+export function IsNotBlank(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: "isNotBlank",
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          return typeof value === "string" && value.trim().length > 0;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property}은(는) 비워둘 수 없습니다.`;
+        },
+      },
+    });
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { ValidationPipe } from "@nestjs/common";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -19,6 +20,15 @@ async function bootstrap() {
       defaultModelExpandDepth: 2, // 각 스키마 상세 열린 상태로
     },
   });
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // DTO에 정의되지 않은 속성 제거
+      forbidNonWhitelisted: true, // DTO에 없는 속성이 들어오면 에러
+      transform: true, // 요청 객체를 DTO 클래스로 변환
+      skipMissingProperties: false, // PATCH 시에도 누락된 필드 검증
+    }),
+  );
 
   await app.listen(3000);
 }

--- a/src/post-comments/dto/comment.dto.ts
+++ b/src/post-comments/dto/comment.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { User } from "src/users/users.entity";
+import { Post } from "src/posts/posts.entity";
+import { Expose } from "class-transformer";
+
+export class CommentDto {
+  @ApiProperty({ example: 1 })
+  @Expose()
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  @Expose()
+  postId: Post["id"];
+
+  @ApiProperty({ example: 1 })
+  @Expose()
+  userId: User["id"];
+
+  @ApiProperty({ example: "댓글 내용" })
+  @Expose()
+  content: string;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @Expose()
+  createdAt: Date;
+}

--- a/src/post-comments/dto/createComment.dto.ts
+++ b/src/post-comments/dto/createComment.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotBlank } from "src/common/validators";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateCommentDto {
+  @ApiProperty({ example: "댓글 내용" })
+  @IsNotBlank()
+  content?: string;
+}

--- a/src/post-comments/dto/updateComment.dto.ts
+++ b/src/post-comments/dto/updateComment.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional } from "class-validator";
+import { IsNotBlank } from "../../common/validators";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UpdateCommentDto {
+  @ApiProperty({ example: "댓글 내용" })
+  @IsNotBlank()
+  @IsOptional()
+  content?: string;
+}

--- a/src/post-comments/post-comments.controller.ts
+++ b/src/post-comments/post-comments.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Post, Body, Param } from "@nestjs/common";
+import { PostCommentsService } from "./post-comments.service";
+import { CreateCommentDto } from "./dto/createComment.dto";
+import { ApiTags } from "@nestjs/swagger";
+
+@ApiTags("Comments")
+@Controller("posts/:postId/comments")
+export class PostCommentsController {
+  constructor(private readonly postCommentsService: PostCommentsService) {}
+
+  @Post()
+  create(@Param("postId") postId: number, @Body() createCommentDto: CreateCommentDto) {
+    return this.postCommentsService.createComment(postId, createCommentDto);
+  }
+}

--- a/src/post-comments/post-comments.entity.ts
+++ b/src/post-comments/post-comments.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from "typeorm";
+import { Post } from "../posts/posts.entity";
+import { User } from "../users/users.entity";
+
+@Entity({ name: "comments" })
+export class Comment {
+  @PrimaryGeneratedColumn("increment")
+  id: number;
+
+  @ManyToOne(() => Post, (p) => p.comments, { onDelete: "CASCADE" })
+  post: Post;
+
+  @ManyToOne(() => User, (u) => u.comments, { nullable: false, onDelete: "CASCADE" })
+  user: User;
+
+  @Column({ type: "text" })
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/post-comments/post-comments.module.ts
+++ b/src/post-comments/post-comments.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Comment } from "./post-comments.entity";
+import { PostCommentsController } from "./post-comments.controller";
+import { PostCommentsService } from "./post-comments.service";
+import { PostsModule } from "../posts/posts.module";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Comment]), PostsModule],
+  controllers: [PostCommentsController],
+  providers: [PostCommentsService],
+})
+export class PostCommentsModule {}

--- a/src/post-comments/post-comments.service.ts
+++ b/src/post-comments/post-comments.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, UpdateResult } from "typeorm";
+import { Comment } from "./post-comments.entity";
+import { CreateCommentDto } from "./dto/createComment.dto";
+import { UpdateCommentDto } from "./dto/updateComment.dto";
+import { CommentDto } from "./dto/comment.dto";
+import { plainToInstance } from "class-transformer";
+
+@Injectable()
+export class PostCommentsService {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+  ) {}
+
+  async createComment(postId: number, createCommentDto: CreateCommentDto): Promise<Comment> {
+    const entity = this.commentRepository.create({
+      post: { id: postId },
+      ...createCommentDto,
+    });
+    return await this.commentRepository.save(entity);
+  }
+
+  async findAll(): Promise<CommentDto[]> {
+    const result = await this.commentRepository.find({
+      relations: ["post", "user"],
+    });
+    return plainToInstance(CommentDto, result, { excludeExtraneousValues: true });
+  }
+
+  async updateComment(id: number, dto: UpdateCommentDto): Promise<UpdateResult> {
+    return await this.commentRepository.update(id, dto);
+  }
+
+  async deleteComment(id: number): Promise<void> {
+    const result = await this.commentRepository.delete(id);
+    if (result.affected === 0) {
+      throw new Error(`댓글 with ID ${id} not found`);
+    }
+  }
+}

--- a/src/post-likes/post-likes.entity.ts
+++ b/src/post-likes/post-likes.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn, Unique } from "typeorm";
+import { Post } from "../posts/posts.entity";
+import { User } from "../users/users.entity";
+
+@Entity({ name: "likes" })
+@Unique(["post", "user"]) // 한 유저가 같은 포스트에 여러 번 좋아요 못누르도록
+export class PostLike {
+  @PrimaryGeneratedColumn("increment")
+  id: number;
+
+  @ManyToOne(() => Post, (p) => p.likes, { onDelete: "CASCADE" })
+  post: Post;
+
+  @ManyToOne(() => User, (u) => u.likes, { onDelete: "CASCADE" })
+  user: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/posts/dto/createPost.dto.ts
+++ b/src/posts/dto/createPost.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsNumber, IsNotEmpty } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotBlank } from "../../common/validators";
+import { Type } from "class-transformer";
+
+export class CreatePostDto {
+  // @TODO: 작성자 ID 받지 않고 로그인 사용자 정보 받기
+  @ApiProperty({ example: 1, description: "작성자 ID" })
+  @IsNumber()
+  @Type(() => Number)
+  @IsNotEmpty()
+  userId: number;
+
+  @ApiProperty({ example: "게시글 제목" })
+  @IsOptional()
+  @IsNotBlank()
+  title: string;
+
+  @ApiProperty({ example: "게시글 내용" })
+  @IsNotBlank()
+  content: string;
+}

--- a/src/posts/dto/getPost.dto.ts
+++ b/src/posts/dto/getPost.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { PostDto } from "./post.dto";
+
+export class GetPostDto {
+  @ApiProperty({ type: [PostDto] })
+  data: PostDto[];
+
+  @ApiProperty({ example: 10 })
+  total: number;
+
+  @ApiProperty({ example: 1 })
+  page: number;
+
+  @ApiProperty({ example: 10 })
+  limit: number;
+
+  @ApiProperty({ example: 1 })
+  totalPages: number;
+}

--- a/src/posts/dto/post.dto.ts
+++ b/src/posts/dto/post.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { CommentDto } from "src/post-comments/dto/comment.dto";
+import { Expose, Type } from "class-transformer";
+import { UserDto } from "src/users/dto/user.dto";
+
+export class PostDto {
+  @ApiProperty({ example: 1 })
+  @Expose()
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  @Expose()
+  @Type(() => UserDto)
+  user: UserDto;
+
+  @ApiProperty({ example: "게시글 제목" })
+  @Expose()
+  title: string;
+
+  @ApiProperty({ example: "게시글 내용" })
+  @Expose()
+  content: string;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @Expose()
+  createdAt: Date;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @Expose()
+  updatedAt: Date;
+
+  @ApiProperty({ type: [CommentDto] })
+  @Expose()
+  comments: CommentDto[];
+
+  @ApiProperty({ example: 1 })
+  @Expose()
+  likesCount: number;
+}

--- a/src/posts/dto/updatePost.dto.ts
+++ b/src/posts/dto/updatePost.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional } from "class-validator";
+import { IsNotBlank } from "src/common/validators";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UpdatePostDto {
+  @ApiProperty({ example: "게시글 제목" })
+  @IsOptional()
+  @IsNotBlank()
+  title?: string;
+
+  @ApiProperty({ example: "게시글 내용" })
+  @IsNotBlank()
+  content?: string;
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Post, Body, Get, Query, Param, Patch, Delete } from "@nestjs/common";
+import { PostsService } from "./posts.service";
+import { CreatePostDto } from "./dto/createPost.dto";
+import { ApiOkResponse, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { GetPostDto } from "./dto/getPost.dto";
+import { UpdatePostDto } from "./dto/updatePost.dto";
+import { PostDto } from "./dto/post.dto";
+
+@ApiTags("Posts")
+@Controller("posts")
+export class PostsController {
+  constructor(private readonly postsService: PostsService) {}
+
+  @Post()
+  createPost(@Body() createPostDto: CreatePostDto) {
+    return this.postsService.createPost(createPostDto);
+  }
+
+  @Get()
+  @ApiQuery({ name: "page", required: false, example: 1 })
+  @ApiQuery({ name: "limit", required: false, example: 10 })
+  @ApiOkResponse({ type: GetPostDto, description: "게시글 목록" })
+  getPosts(@Query("page") page: number, @Query("limit") limit: number) {
+    if (!page || !limit) {
+      return this.postsService.findAllPosts();
+    }
+    return this.postsService.findAllPostWithPagination(Number(page), Number(limit));
+  }
+
+  @Get(":id")
+  @ApiOkResponse({ type: PostDto, description: "게시글 상세" })
+  getPostById(@Param("id") id: number) {
+    return this.postsService.findPostById(id);
+  }
+
+  @Patch(":id")
+  updatePost(@Param("id") id: number, @Body() updatePostDto: UpdatePostDto) {
+    return this.postsService.updatePost(id, updatePostDto);
+  }
+
+  @Delete(":id")
+  deletePost(@Param("id") id: number) {
+    return this.postsService.deletePost(id);
+  }
+}

--- a/src/posts/posts.entity.ts
+++ b/src/posts/posts.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+} from "typeorm";
+import { User } from "../users/users.entity";
+import { Comment } from "../post-comments/post-comments.entity";
+import { PostLike } from "../post-likes/post-likes.entity";
+import { ApiProperty } from "@nestjs/swagger";
+
+@Entity({ name: "posts" })
+export class Post {
+  @ApiProperty({ example: 1 })
+  @PrimaryGeneratedColumn("increment")
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  @ManyToOne(() => User, (u) => u.posts, { nullable: false, onDelete: "CASCADE" })
+  user: User;
+
+  @ApiProperty({ example: "게시글 제목" })
+  @Column({ type: "varchar", length: 255, nullable: false })
+  title: string;
+
+  @ApiProperty({ example: "게시글 내용" })
+  @Column({ type: "text", nullable: false })
+  content: string;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @OneToMany(() => Comment, (c) => c.post, { cascade: true })
+  comments: Comment[];
+
+  @OneToMany(() => PostLike, (l) => l.post, { cascade: true })
+  likes: PostLike[];
+}

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { PostsController } from "./posts.controller";
+import { PostsService } from "./posts.service";
+import { Post } from "./posts.entity";
+import { User } from "../users/users.entity";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Post, User])],
+  controllers: [PostsController],
+  providers: [PostsService],
+  exports: [PostsService],
+})
+export class PostsModule {}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, UpdateResult } from "typeorm";
+import { Post } from "./posts.entity";
+import { CreatePostDto } from "./dto/createPost.dto";
+import { UpdatePostDto } from "./dto/updatePost.dto";
+import { GetPostDto } from "./dto/getPost.dto";
+import { plainToInstance } from "class-transformer";
+import { PostDto } from "./dto/post.dto";
+import { User } from "../users/users.entity";
+
+@Injectable()
+export class PostsService {
+  constructor(
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async createPost(createPostDto: CreatePostDto): Promise<Post> {
+    const { userId, ...postData } = createPostDto;
+
+    // 사용자 존재 여부 확인
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`ID ${userId}에 해당하는 사용자를 찾을 수 없습니다.`);
+    }
+
+    const entity = this.postRepository.create({
+      user: { id: userId },
+      ...postData,
+    });
+    return await this.postRepository.save(entity);
+  }
+
+  // 전체 목록
+  async findAllPosts(): Promise<GetPostDto> {
+    const result = await this.postRepository.find({
+      order: { createdAt: "DESC" },
+      relations: ["comments", "likes", "user"],
+    });
+
+    const data = result.map((post) => ({
+      ...post,
+      likesCount: post.likes.length || 0,
+    }));
+
+    return {
+      data: plainToInstance(PostDto, data, { excludeExtraneousValues: true }),
+      limit: data.length,
+      total: data.length,
+      page: 1,
+      totalPages: 1,
+    };
+  }
+
+  // 페이지네이션 목록
+  async findAllPostWithPagination(page: number, limit: number): Promise<GetPostDto> {
+    const [result, total] = await this.postRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { createdAt: "DESC" },
+      relations: ["comments", "likes", "user"],
+    });
+
+    const data = result.map((post) => ({
+      ...post,
+      likesCount: post.likes.length || 0,
+    }));
+
+    return {
+      data: plainToInstance(PostDto, data, { excludeExtraneousValues: true }),
+      limit,
+      total,
+      page,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async findPostById(id: number): Promise<PostDto> {
+    const post = await this.postRepository.findOne({
+      where: { id },
+      relations: ["comments", "likes", "user"],
+    });
+    if (!post) {
+      throw new NotFoundException(`게시글 with ID ${id} not found`);
+    }
+    return plainToInstance(PostDto, post, { excludeExtraneousValues: true });
+  }
+
+  async updatePost(id: number, dto: UpdatePostDto): Promise<UpdateResult> {
+    return await this.postRepository.update(id, dto);
+  }
+
+  async deletePost(id: number): Promise<void> {
+    const result = await this.postRepository.delete(id);
+    if (result.affected === 0) {
+      throw new Error(`게시글 with ID ${id} not found`);
+    }
+  }
+}

--- a/src/users/dto/user.dto.ts
+++ b/src/users/dto/user.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
+
+export class UserDto {
+  @ApiProperty({ example: 1 })
+  @Expose()
+  id: number;
+
+  @ApiProperty({ example: "홍길동" })
+  @Expose()
+  username: string;
+}

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -1,4 +1,7 @@
-import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+import { Comment } from "src/post-comments/post-comments.entity";
+import { PostLike } from "src/post-likes/post-likes.entity";
+import { Post } from "src/posts/posts.entity";
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from "typeorm";
 
 @Entity()
 export class User {
@@ -10,4 +13,13 @@ export class User {
 
   @Column()
   email: string;
+
+  @OneToMany(() => Post, (p) => p.user)
+  posts: Post[];
+
+  @OneToMany(() => Comment, (c) => c.user)
+  comments: Comment[];
+
+  @OneToMany(() => PostLike, (l) => l.user)
+  likes: PostLike[];
 }


### PR DESCRIPTION
### 이슈 #9 

### 작업 내용
- 게시글 api 기능 추가
  - 게시글 생성
  - 게시글 전체 조회 (페이지네이션 가능)
  - 게시글 상세 조회 (id 기반)
  - 게시글 수정
  - 게시글 삭제
- 게시글, 좋아요, 댓글
- api 요청 시 데이터 유효성 검증 설정

### 노트
- 유저 인증, 권한 기능은 제외된 상태로 추후에 추가할 예정입니다
- 좋아요, 댓글 기능을 위한 entity와 초기 구성 느낌 정도만 정의했습니다