### PR TITLE
feat: 게시글 get 요청 시 응답 세분화(게시글 목록, 게시글 상세)

### DIFF
--- a/src/posts/dto/getPost.dto.ts
+++ b/src/posts/dto/getPost.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { PostDto } from "./post.dto";
+import { PostListDto } from "./postList.dto";
 
 export class GetPostDto {
-  @ApiProperty({ type: [PostDto] })
-  data: PostDto[];
+  @ApiProperty({ type: [PostListDto] })
+  data: PostListDto[];
 
   @ApiProperty({ example: 10 })
   total: number;

--- a/src/posts/dto/postDetail.dto.ts
+++ b/src/posts/dto/postDetail.dto.ts
@@ -3,12 +3,12 @@ import { CommentDto } from "src/post-comments/dto/comment.dto";
 import { Expose, Type } from "class-transformer";
 import { UserDto } from "src/users/dto/user.dto";
 
-export class PostDto {
+export class PostDetailDto {
   @ApiProperty({ example: 1 })
   @Expose()
   id: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ type: () => UserDto })
   @Expose()
   @Type(() => UserDto)
   user: UserDto;
@@ -32,8 +32,4 @@ export class PostDto {
   @ApiProperty({ type: [CommentDto] })
   @Expose()
   comments: CommentDto[];
-
-  @ApiProperty({ example: 1 })
-  @Expose()
-  likesCount: number;
 }

--- a/src/posts/dto/postList.dto.ts
+++ b/src/posts/dto/postList.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose, Type } from "class-transformer";
+import { UserDto } from "src/users/dto/user.dto";
+
+export class PostListDto {
+  @ApiProperty({ example: 1 })
+  @Expose()
+  id: number;
+
+  @ApiProperty({ type: () => UserDto })
+  @Expose()
+  @Type(() => UserDto)
+  user: UserDto;
+
+  @ApiProperty({ example: "게시글 제목" })
+  @Expose()
+  title: string;
+
+  @ApiProperty({ example: "게시글 내용" })
+  @Expose()
+  content: string;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @Expose()
+  createdAt: Date;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @Expose()
+  updatedAt: Date;
+
+  @ApiProperty({ example: 1 })
+  @Expose()
+  likesCount: number;
+
+  @ApiProperty({ example: 1 })
+  @Expose()
+  commentsCount: number;
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -4,7 +4,7 @@ import { CreatePostDto } from "./dto/createPost.dto";
 import { ApiOkResponse, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { GetPostDto } from "./dto/getPost.dto";
 import { UpdatePostDto } from "./dto/updatePost.dto";
-import { PostDto } from "./dto/post.dto";
+import { PostDetailDto } from "./dto/postDetail.dto";
 
 @ApiTags("Posts")
 @Controller("posts")
@@ -28,7 +28,7 @@ export class PostsController {
   }
 
   @Get(":id")
-  @ApiOkResponse({ type: PostDto, description: "게시글 상세" })
+  @ApiOkResponse({ type: PostDetailDto, description: "게시글 상세" })
   getPostById(@Param("id") id: number) {
     return this.postsService.findPostById(id);
   }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -6,7 +6,8 @@ import { CreatePostDto } from "./dto/createPost.dto";
 import { UpdatePostDto } from "./dto/updatePost.dto";
 import { GetPostDto } from "./dto/getPost.dto";
 import { plainToInstance } from "class-transformer";
-import { PostDto } from "./dto/post.dto";
+import { PostListDto } from "./dto/postList.dto";
+import { PostDetailDto } from "./dto/postDetail.dto";
 import { User } from "../users/users.entity";
 
 @Injectable()
@@ -44,10 +45,11 @@ export class PostsService {
     const data = result.map((post) => ({
       ...post,
       likesCount: post.likes.length || 0,
+      commentsCount: post.comments.length || 0,
     }));
 
     return {
-      data: plainToInstance(PostDto, data, { excludeExtraneousValues: true }),
+      data: plainToInstance(PostListDto, data, { excludeExtraneousValues: true }),
       limit: data.length,
       total: data.length,
       page: 1,
@@ -67,10 +69,11 @@ export class PostsService {
     const data = result.map((post) => ({
       ...post,
       likesCount: post.likes.length || 0,
+      commentsCount: post.comments.length || 0,
     }));
 
     return {
-      data: plainToInstance(PostDto, data, { excludeExtraneousValues: true }),
+      data: plainToInstance(PostListDto, data, { excludeExtraneousValues: true }),
       limit,
       total,
       page,
@@ -78,7 +81,7 @@ export class PostsService {
     };
   }
 
-  async findPostById(id: number): Promise<PostDto> {
+  async findPostById(id: number): Promise<PostDetailDto> {
     const post = await this.postRepository.findOne({
       where: { id },
       relations: ["comments", "likes", "user"],
@@ -86,7 +89,7 @@ export class PostsService {
     if (!post) {
       throw new NotFoundException(`게시글 with ID ${id} not found`);
     }
-    return plainToInstance(PostDto, post, { excludeExtraneousValues: true });
+    return plainToInstance(PostDetailDto, post, { excludeExtraneousValues: true });
   }
 
   async updatePost(id: number, dto: UpdatePostDto): Promise<UpdateResult> {


### PR DESCRIPTION
### 작업 내용 ###
- GET 요청 시 엔드포인트에 따라 게시글 목록과 게시글 상세의 응답 정보를 다르게 전달
- PostDto를 PostListDto와 PostDetailDto로 분리하여 관리

close #14 