### PR TITLE
refactor: ♻️ 카톡로그인 클라에서 넘기는 형태와 맞춤 (token: string)

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -50,7 +50,7 @@ export class AuthController {
   @Post("sign-in/kakao")
   @HttpCode(HttpStatus.OK)
   async signinWithKakaoCode(@Body() dto: KakaoCodeDto) {
-    return await this.authService.signinWithKakaoCode(dto.code);
+    return await this.authService.signinWithKakaoToken(dto.token);
   }
 
   /**
@@ -66,7 +66,7 @@ export class AuthController {
   @Get("sign-in/kakao/callback")
   @HttpCode(HttpStatus.OK)
   async signinWithKakaoTestCallback(@Query("code") code: string) {
-    return await this.authService.signinWithKakaoCode(code);
+    return await this.authService.signinWithKakaoToken(code);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/auth/dto/kakaoCode.dto.ts
+++ b/src/auth/dto/kakaoCode.dto.ts
@@ -2,5 +2,5 @@ import { IsNotBlank } from "src/common/validators";
 
 export class KakaoCodeDto {
   @IsNotBlank()
-  code: string;
+  token: string;
 }


### PR DESCRIPTION
드디어 카톡로그인 되는 것 까지 봤네요 후~!

### 작업내용
- authCode -> token 발급 절차까지를 클라에서 처리
- redirect url 등의 env는 이제 테스트용으로만 쓰이게 되었습니다. (사실상 클라에서만 관리되면 되네요)

https://github.com/user-attachments/assets/81084d5a-4380-42ea-a15d-b600c7e665cb

