### PR TITLE
feat: 게시글/댓글 좋아요 기능 및 토글 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import { PostsModule } from "./posts/posts.module";
 import { PostCommentsModule } from "./post-comments/post-comments.module";
 import { AuthModule } from "./auth/auth.module";
 import { DatabaseSeederModule } from "./database/database-seeder.module";
+import { PostLikesModule } from "./post-likes/post-likes.module";
+import { CommentLikesModule } from "./comment-likes/comment-likes.module";
 
 @Module({
   imports: [
@@ -33,6 +35,8 @@ import { DatabaseSeederModule } from "./database/database-seeder.module";
     UsersModule,
     PostsModule,
     PostCommentsModule,
+    PostLikesModule,
+    CommentLikesModule,
     AuthModule,
     DatabaseSeederModule,
   ],

--- a/src/auth/optional-jwt-auth.guard.ts
+++ b/src/auth/optional-jwt-auth.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { JwtPayload } from "./dto/jwtPayload.dto";
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard("jwt") {
+  // 인증 실패 시에도 에러를 던지지 않고 계속 진행
+  handleRequest<TUser = JwtPayload>(err: Error | null, user: TUser | false): TUser | null {
+    // 에러가 있어도 무시하고, user가 있으면 반환, 없으면 null 반환
+    if (err || !user) {
+      return null;
+    }
+    return user as TUser;
+  }
+}

--- a/src/comment-likes/comment-likes.controller.ts
+++ b/src/comment-likes/comment-likes.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Post, Param, UseGuards, Request, HttpCode, HttpStatus } from "@nestjs/common";
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from "@nestjs/swagger";
+import { CommentLikesService } from "./comment-likes.service";
+import { JwtAuthGuard } from "../auth/auth.guard";
+import type { RequestWithUser } from "../common/requests/requestWithUser";
+
+@ApiTags("Comment Likes")
+@Controller("comments/:commentId/likes")
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class CommentLikesController {
+  constructor(private readonly commentLikesService: CommentLikesService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "댓글 좋아요 토글 (좋아요 추가/취소)" })
+  @ApiParam({ name: "commentId", description: "댓글 ID", type: Number })
+  @ApiResponse({
+    status: 200,
+    description: "좋아요 토글 성공",
+    schema: {
+      properties: {
+        message: { type: "string", example: "좋아요를 추가했습니다." },
+        isLiked: { type: "boolean", example: true },
+        count: { type: "number", example: 0 },
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: "댓글을 찾을 수 없음" })
+  async toggleLike(@Param("commentId") commentId: number, @Request() req: RequestWithUser) {
+    const result = await this.commentLikesService.toggleLike(commentId, req.user);
+    return {
+      message: result.isLiked ? "좋아요를 추가했습니다." : "좋아요를 취소했습니다.",
+      ...result,
+    };
+  }
+}

--- a/src/comment-likes/comment-likes.entity.ts
+++ b/src/comment-likes/comment-likes.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn, Unique } from "typeorm";
+import { Comment } from "../post-comments/post-comments.entity";
+import { User } from "../users/users.entity";
+
+@Entity({ name: "comment_likes" })
+@Unique(["comment", "user"]) // 한 유저가 같은 댓글에 여러 번 좋아요 못누르도록
+export class CommentLike {
+  @PrimaryGeneratedColumn("increment")
+  id: number;
+
+  @ManyToOne(() => Comment, (c) => c.likes, { onDelete: "CASCADE" })
+  comment: Comment;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  user: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/comment-likes/comment-likes.module.ts
+++ b/src/comment-likes/comment-likes.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { CommentLike } from "./comment-likes.entity";
+import { CommentLikesController } from "./comment-likes.controller";
+import { CommentLikesService } from "./comment-likes.service";
+import { Comment } from "../post-comments/post-comments.entity";
+import { AuthModule } from "../auth/auth.module";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CommentLike, Comment]), AuthModule],
+  controllers: [CommentLikesController],
+  providers: [CommentLikesService],
+  exports: [CommentLikesService],
+})
+export class CommentLikesModule {}

--- a/src/comment-likes/comment-likes.service.ts
+++ b/src/comment-likes/comment-likes.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { CommentLike } from "./comment-likes.entity";
+import { Comment } from "../post-comments/post-comments.entity";
+import { JwtPayload } from "../auth/dto/jwtPayload.dto";
+
+@Injectable()
+export class CommentLikesService {
+  constructor(
+    @InjectRepository(CommentLike)
+    private readonly commentLikeRepository: Repository<CommentLike>,
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+  ) {}
+
+  async toggleLike(
+    commentId: number,
+    user: JwtPayload,
+  ): Promise<{ isLiked: boolean; count: number }> {
+    // 댓글 존재 여부 확인
+    const comment = await this.commentRepository.findOne({ where: { id: commentId } });
+    if (!comment) {
+      throw new NotFoundException(`ID ${commentId}에 해당하는 댓글을 찾을 수 없습니다.`);
+    }
+
+    // 이미 좋아요를 눌렀는지 확인
+    const existingLike = await this.commentLikeRepository.findOne({
+      where: {
+        comment: { id: commentId },
+        user: { id: user.id },
+      },
+    });
+
+    let isLiked: boolean;
+
+    if (existingLike) {
+      // 좋아요가 있으면 삭제
+      await this.commentLikeRepository.remove(existingLike);
+      isLiked = false;
+    } else {
+      // 좋아요가 없으면 추가
+      const like = this.commentLikeRepository.create({
+        comment: { id: commentId },
+        user: { id: user.id },
+      });
+      await this.commentLikeRepository.save(like);
+      isLiked = true;
+    }
+
+    // 현재 좋아요 개수 조회
+    const count = await this.getLikeCount(commentId);
+
+    return { isLiked, count };
+  }
+
+  async checkLikeStatus(commentId: number, user: JwtPayload): Promise<boolean> {
+    const like = await this.commentLikeRepository.findOne({
+      where: {
+        comment: { id: commentId },
+        user: { id: user.id },
+      },
+    });
+
+    return !!like;
+  }
+
+  async getLikeCount(commentId: number): Promise<number> {
+    return await this.commentLikeRepository.count({
+      where: { comment: { id: commentId } },
+    });
+  }
+}

--- a/src/common/requests/requestWithUser.ts
+++ b/src/common/requests/requestWithUser.ts
@@ -6,6 +6,10 @@ export interface RequestWithUser extends Request {
   user: JwtPayload;
 }
 
+export interface RequestWithOptionalUser extends Request {
+  user?: JwtPayload; // Optional: 로그인 안 한 경우 undefined
+}
+
 export interface RequestWithSocialLoginUser extends Request {
   user: SocialLoginDto;
 }

--- a/src/post-comments/dto/comment.dto.ts
+++ b/src/post-comments/dto/comment.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { User } from "src/users/users.entity";
 import { Post } from "src/posts/posts.entity";
-import { Expose } from "class-transformer";
+import { Expose, Type } from "class-transformer";
+import { UserDto } from "src/users/dto/user.dto";
 
 export class CommentDto {
   @ApiProperty({ example: 1 })
@@ -12,15 +12,37 @@ export class CommentDto {
   @Expose()
   postId: Post["id"];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ type: () => UserDto })
   @Expose()
-  userId: User["id"];
+  @Type(() => UserDto)
+  user: UserDto;
 
   @ApiProperty({ example: "댓글 내용" })
   @Expose()
   content: string;
 
+  @ApiProperty({ example: null, description: "부모 댓글 ID (대댓글인 경우)" })
+  @Expose()
+  parentCommentId: number | null;
+
+  @ApiProperty({ example: [], description: "대댓글 목록", type: () => [CommentDto] })
+  @Expose()
+  @Type(() => CommentDto)
+  replies: CommentDto[];
+
+  @ApiProperty({ example: 0, description: "좋아요 개수" })
+  @Expose()
+  likeCount: number;
+
+  @ApiProperty({ example: false, description: "내가 좋아요를 눌렀는지 여부 (로그인 시에만)" })
+  @Expose()
+  isLikedByMe: boolean;
+
   @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
   @Expose()
   createdAt: Date;
+
+  @ApiProperty({ example: "2025-10-28T19:26:42.461Z" })
+  @Expose()
+  updatedAt: Date;
 }

--- a/src/post-comments/dto/createComment.dto.ts
+++ b/src/post-comments/dto/createComment.dto.ts
@@ -1,8 +1,20 @@
 import { IsNotBlank } from "src/common/validators";
 import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional, IsNumber } from "class-validator";
+import { Type } from "class-transformer";
 
 export class CreateCommentDto {
   @ApiProperty({ example: "댓글 내용" })
   @IsNotBlank()
   content?: string;
+
+  @ApiProperty({
+    example: 1,
+    description: "부모 댓글 ID (대댓글인 경우에만 필요)",
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  parentCommentId?: number;
 }

--- a/src/post-comments/post-comments.controller.ts
+++ b/src/post-comments/post-comments.controller.ts
@@ -1,7 +1,23 @@
-import { Controller, Post, Body, Param } from "@nestjs/common";
+import {
+  Controller,
+  Post,
+  Body,
+  Param,
+  Get,
+  Patch,
+  Delete,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from "@nestjs/common";
 import { PostCommentsService } from "./post-comments.service";
 import { CreateCommentDto } from "./dto/createComment.dto";
-import { ApiTags } from "@nestjs/swagger";
+import { UpdateCommentDto } from "./dto/updateComment.dto";
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiResponse } from "@nestjs/swagger";
+import { JwtAuthGuard } from "../auth/auth.guard";
+import { OptionalJwtAuthGuard } from "../auth/optional-jwt-auth.guard";
+import type { RequestWithUser, RequestWithOptionalUser } from "../common/requests/requestWithUser";
 
 @ApiTags("Comments")
 @Controller("posts/:postId/comments")
@@ -9,7 +25,53 @@ export class PostCommentsController {
   constructor(private readonly postCommentsService: PostCommentsService) {}
 
   @Post()
-  create(@Param("postId") postId: number, @Body() createCommentDto: CreateCommentDto) {
-    return this.postCommentsService.createComment(postId, createCommentDto);
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: "댓글 작성 (대댓글 포함)",
+    description: "대댓글 작성 시 'parentCommentId' 필요</br> 대댓글의 댓글은 작성 불가",
+  })
+  @ApiParam({ name: "postId", description: "게시글 ID", type: Number })
+  @ApiResponse({ status: 400, description: "대댓글의 댓글은 작성 불가" })
+  create(
+    @Param("postId") postId: number,
+    @Body() createCommentDto: CreateCommentDto,
+    @Request() req: RequestWithUser,
+  ) {
+    return this.postCommentsService.createComment(postId, createCommentDto, req.user);
+  }
+
+  @Get()
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: "게시글의 댓글 목록 조회 (대댓글 포함)" })
+  @ApiParam({ name: "postId", description: "게시글 ID", type: Number })
+  findByPostId(@Param("postId") postId: number, @Request() req: RequestWithOptionalUser) {
+    const userId = req.user?.id; // 로그인한 경우에만 userId 존재
+    return this.postCommentsService.findByPostId(postId, userId);
+  }
+
+  @Patch(":commentId")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "댓글 수정" })
+  @ApiParam({ name: "postId", description: "게시글 ID", type: Number })
+  @ApiParam({ name: "commentId", description: "댓글 ID", type: Number })
+  update(
+    @Param("commentId") commentId: number,
+    @Body() updateCommentDto: UpdateCommentDto,
+    @Request() req: RequestWithUser,
+  ) {
+    return this.postCommentsService.updateComment(commentId, updateCommentDto, req.user);
+  }
+
+  @Delete(":commentId")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: "댓글 삭제" })
+  @ApiParam({ name: "postId", description: "게시글 ID", type: Number })
+  @ApiParam({ name: "commentId", description: "댓글 ID", type: Number })
+  async delete(@Param("commentId") commentId: number, @Request() req: RequestWithUser) {
+    await this.postCommentsService.deleteComment(commentId, req.user);
   }
 }

--- a/src/post-comments/post-comments.entity.ts
+++ b/src/post-comments/post-comments.entity.ts
@@ -1,6 +1,15 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from "typeorm";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
 import { Post } from "../posts/posts.entity";
 import { User } from "../users/users.entity";
+import { CommentLike } from "../comment-likes/comment-likes.entity";
 
 @Entity({ name: "comments" })
 export class Comment {
@@ -16,6 +25,21 @@ export class Comment {
   @Column({ type: "text" })
   content: string;
 
+  // 부모 댓글 (대댓글인 경우에만 값이 있음)
+  @ManyToOne(() => Comment, (c) => c.replies, { nullable: true, onDelete: "CASCADE" })
+  parentComment: Comment | null;
+
+  // 자식 댓글들 (대댓글 목록)
+  @OneToMany(() => Comment, (c) => c.parentComment)
+  replies: Comment[];
+
+  // 댓글 좋아요
+  @OneToMany(() => CommentLike, (l) => l.comment, { cascade: true })
+  likes: CommentLike[];
+
   @CreateDateColumn()
   createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/src/post-comments/post-comments.module.ts
+++ b/src/post-comments/post-comments.module.ts
@@ -1,13 +1,14 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { Comment } from "./post-comments.entity";
+import { Post } from "../posts/posts.entity";
 import { PostCommentsController } from "./post-comments.controller";
 import { PostCommentsService } from "./post-comments.service";
-import { PostsModule } from "../posts/posts.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Comment]), PostsModule],
+  imports: [TypeOrmModule.forFeature([Comment, Post])],
   controllers: [PostCommentsController],
   providers: [PostCommentsService],
+  exports: [PostCommentsService],
 })
 export class PostCommentsModule {}

--- a/src/post-comments/post-comments.service.ts
+++ b/src/post-comments/post-comments.service.ts
@@ -1,42 +1,159 @@
-import { Injectable } from "@nestjs/common";
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, UpdateResult } from "typeorm";
+import { Repository, UpdateResult, IsNull } from "typeorm";
 import { Comment } from "./post-comments.entity";
+import { Post } from "../posts/posts.entity";
 import { CreateCommentDto } from "./dto/createComment.dto";
 import { UpdateCommentDto } from "./dto/updateComment.dto";
 import { CommentDto } from "./dto/comment.dto";
 import { plainToInstance } from "class-transformer";
+import { JwtPayload } from "../auth/dto/jwtPayload.dto";
 
 @Injectable()
 export class PostCommentsService {
   constructor(
     @InjectRepository(Comment)
     private readonly commentRepository: Repository<Comment>,
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
   ) {}
 
-  async createComment(postId: number, createCommentDto: CreateCommentDto): Promise<Comment> {
+  async createComment(
+    postId: number,
+    createCommentDto: CreateCommentDto,
+    user: JwtPayload,
+  ): Promise<Comment> {
+    // 게시글 존재 여부 확인
+    const post = await this.postRepository.findOne({ where: { id: postId } });
+    if (!post) {
+      throw new NotFoundException(`ID ${postId}에 해당하는 게시글을 찾을 수 없습니다.`);
+    }
+
+    const { parentCommentId, content } = createCommentDto;
+
+    // 대댓글인 경우
+    if (parentCommentId) {
+      const parentComment = await this.commentRepository.findOne({
+        where: { id: parentCommentId },
+        relations: ["parentComment"],
+      });
+
+      if (!parentComment) {
+        throw new NotFoundException(`ID ${parentCommentId}에 해당하는 댓글을 찾을 수 없습니다.`);
+      }
+
+      // 부모 댓글이 이미 대댓글이면 3단계가 되므로 막기
+      if (parentComment.parentComment !== null) {
+        throw new BadRequestException("대댓글의 댓글은 작성할 수 없습니다.");
+      }
+
+      const entity = this.commentRepository.create({
+        post: { id: postId },
+        user: { id: user.id },
+        content,
+        parentComment: { id: parentCommentId },
+      });
+
+      return await this.commentRepository.save(entity);
+    }
+
+    // 일반 댓글
     const entity = this.commentRepository.create({
       post: { id: postId },
-      ...createCommentDto,
+      user: { id: user.id },
+      content,
     });
+
     return await this.commentRepository.save(entity);
   }
 
-  async findAll(): Promise<CommentDto[]> {
-    const result = await this.commentRepository.find({
-      relations: ["post", "user"],
+  async findByPostId(postId: number, userId?: number): Promise<CommentDto[]> {
+    // 부모 댓글만 조회 (대댓글은 replies로 가져옴)
+    const comments = await this.commentRepository.find({
+      where: {
+        post: { id: postId },
+        parentComment: IsNull(),
+      },
+      relations: [
+        "user",
+        "replies",
+        "replies.user",
+        "likes",
+        "likes.user",
+        "replies.likes",
+        "replies.likes.user",
+      ],
+      order: {
+        createdAt: "ASC",
+        replies: {
+          createdAt: "ASC",
+        },
+      },
     });
-    return plainToInstance(CommentDto, result, { excludeExtraneousValues: true });
+
+    return comments.map((comment) => {
+      const dto = plainToInstance(CommentDto, comment, { excludeExtraneousValues: true });
+      dto.postId = postId;
+      dto.parentCommentId = null;
+      dto.likeCount = comment.likes?.length || 0;
+      dto.isLikedByMe = userId
+        ? comment.likes?.some((like) => like.user.id === userId) || false
+        : false;
+      dto.replies = comment.replies.map((reply) => {
+        const replyDto = plainToInstance(CommentDto, reply, { excludeExtraneousValues: true });
+        replyDto.postId = postId;
+        replyDto.parentCommentId = comment.id;
+        replyDto.likeCount = reply.likes?.length || 0;
+        replyDto.isLikedByMe = userId
+          ? reply.likes?.some((like) => like.user.id === userId) || false
+          : false;
+        replyDto.replies = [];
+        return replyDto;
+      });
+      return dto;
+    });
   }
 
-  async updateComment(id: number, dto: UpdateCommentDto): Promise<UpdateResult> {
+  async updateComment(id: number, dto: UpdateCommentDto, user: JwtPayload): Promise<UpdateResult> {
+    // 댓글 존재 여부 및 작성자 확인
+    const comment = await this.commentRepository.findOne({
+      where: { id },
+      relations: ["user"],
+    });
+
+    if (!comment) {
+      throw new NotFoundException(`ID ${id}에 해당하는 댓글을 찾을 수 없습니다.`);
+    }
+
+    // 작성자 본인인지 확인
+    if (comment.user.id !== user.id) {
+      throw new ForbiddenException("본인의 댓글만 수정할 수 있습니다.");
+    }
+
     return await this.commentRepository.update(id, dto);
   }
 
-  async deleteComment(id: number): Promise<void> {
-    const result = await this.commentRepository.delete(id);
-    if (result.affected === 0) {
-      throw new Error(`댓글 with ID ${id} not found`);
+  async deleteComment(id: number, user: JwtPayload): Promise<void> {
+    // 댓글 존재 여부 및 작성자 확인
+    const comment = await this.commentRepository.findOne({
+      where: { id },
+      relations: ["user"],
+    });
+
+    if (!comment) {
+      throw new NotFoundException(`ID ${id}에 해당하는 댓글을 찾을 수 없습니다.`);
     }
+
+    // 작성자 본인인지 확인
+    if (comment.user.id !== user.id) {
+      throw new ForbiddenException("본인의 댓글만 삭제할 수 있습니다.");
+    }
+
+    await this.commentRepository.delete(id);
   }
 }

--- a/src/post-likes/post-likes.controller.ts
+++ b/src/post-likes/post-likes.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Post, Param, UseGuards, Request, HttpCode, HttpStatus } from "@nestjs/common";
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from "@nestjs/swagger";
+import { PostLikesService } from "./post-likes.service";
+import { JwtAuthGuard } from "../auth/auth.guard";
+import type { RequestWithUser } from "../common/requests/requestWithUser";
+
+@ApiTags("Post Likes")
+@Controller("posts/:postId/likes")
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class PostLikesController {
+  constructor(private readonly postLikesService: PostLikesService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "게시글 좋아요 토글 (좋아요 추가/취소)" })
+  @ApiParam({ name: "postId", description: "게시글 ID", type: Number })
+  @ApiResponse({
+    status: 200,
+    description: "좋아요 토글 성공",
+    schema: {
+      properties: {
+        message: { type: "string", example: "좋아요를 추가했습니다. 또는 취소했습니다." },
+        isLiked: { type: "boolean", example: true },
+        count: { type: "number", example: 1 },
+      },
+    },
+  })
+  async toggleLike(@Param("postId") postId: number, @Request() req: RequestWithUser) {
+    const result = await this.postLikesService.toggleLike(postId, req.user);
+    return {
+      message: result.isLiked ? "좋아요를 추가했습니다." : "좋아요를 취소했습니다.",
+      ...result,
+    };
+  }
+}

--- a/src/post-likes/post-likes.module.ts
+++ b/src/post-likes/post-likes.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { PostLike } from "./post-likes.entity";
+import { Post } from "../posts/posts.entity";
+import { PostLikesController } from "./post-likes.controller";
+import { PostLikesService } from "./post-likes.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PostLike, Post])],
+  controllers: [PostLikesController],
+  providers: [PostLikesService],
+  exports: [PostLikesService],
+})
+export class PostLikesModule {}

--- a/src/post-likes/post-likes.service.ts
+++ b/src/post-likes/post-likes.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { PostLike } from "./post-likes.entity";
+import { Post } from "../posts/posts.entity";
+import { JwtPayload } from "../auth/dto/jwtPayload.dto";
+
+@Injectable()
+export class PostLikesService {
+  constructor(
+    @InjectRepository(PostLike)
+    private readonly postLikeRepository: Repository<PostLike>,
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
+  ) {}
+
+  async toggleLike(postId: number, user: JwtPayload): Promise<{ isLiked: boolean; count: number }> {
+    // 게시글 존재 여부 확인
+    const post = await this.postRepository.findOne({ where: { id: postId } });
+    if (!post) {
+      throw new NotFoundException(`ID ${postId}에 해당하는 게시글을 찾을 수 없습니다.`);
+    }
+
+    // 이미 좋아요를 눌렀는지 확인
+    const existingLike = await this.postLikeRepository.findOne({
+      where: {
+        post: { id: postId },
+        user: { id: user.id },
+      },
+    });
+
+    let isLiked: boolean;
+
+    if (existingLike) {
+      // 좋아요가 있으면 삭제
+      await this.postLikeRepository.remove(existingLike);
+      isLiked = false;
+    } else {
+      // 좋아요가 없으면 추가
+      const like = this.postLikeRepository.create({
+        post: { id: postId },
+        user: { id: user.id },
+      });
+      await this.postLikeRepository.save(like);
+      isLiked = true;
+    }
+
+    // 현재 좋아요 개수 조회
+    const count = await this.getLikeCount(postId);
+
+    return { isLiked, count };
+  }
+
+  async checkLikeStatus(postId: number, user: JwtPayload): Promise<boolean> {
+    const like = await this.postLikeRepository.findOne({
+      where: {
+        post: { id: postId },
+        user: { id: user.id },
+      },
+    });
+
+    return !!like;
+  }
+
+  async getLikeCount(postId: number): Promise<number> {
+    return await this.postLikeRepository.count({
+      where: { post: { id: postId } },
+    });
+  }
+}

--- a/src/posts/dto/postDetail.dto.ts
+++ b/src/posts/dto/postDetail.dto.ts
@@ -29,6 +29,14 @@ export class PostDetailDto {
   @Expose()
   updatedAt: Date;
 
+  @ApiProperty({ example: 0, description: "좋아요 개수" })
+  @Expose()
+  likeCount: number;
+
+  @ApiProperty({ example: false, description: "내가 좋아요를 눌렀는지 여부 (로그인 시에만)" })
+  @Expose()
+  isLikedByMe: boolean;
+
   @ApiProperty({ type: [CommentDto] })
   @Expose()
   comments: CommentDto[];

--- a/src/posts/dto/postList.dto.ts
+++ b/src/posts/dto/postList.dto.ts
@@ -28,11 +28,15 @@ export class PostListDto {
   @Expose()
   updatedAt: Date;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 0, description: "좋아요 개수" })
   @Expose()
-  likesCount: number;
+  likeCount: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 0, description: "댓글 개수" })
   @Expose()
   commentsCount: number;
+
+  @ApiProperty({ example: false, description: "내가 좋아요를 눌렀는지 여부 (로그인 시에만)" })
+  @Expose()
+  isLikedByMe: boolean;
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,10 +1,24 @@
-import { Controller, Post, Body, Get, Query, Param, Patch, Delete } from "@nestjs/common";
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Query,
+  Param,
+  Patch,
+  Delete,
+  UseGuards,
+  Request,
+} from "@nestjs/common";
 import { PostsService } from "./posts.service";
 import { CreatePostDto } from "./dto/createPost.dto";
-import { ApiOkResponse, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { GetPostDto } from "./dto/getPost.dto";
 import { UpdatePostDto } from "./dto/updatePost.dto";
 import { PostDetailDto } from "./dto/postDetail.dto";
+import { OptionalJwtAuthGuard } from "../auth/optional-jwt-auth.guard";
+import type { RequestWithOptionalUser } from "../common/requests/requestWithUser";
+import { JwtAuthGuard } from "src/auth/auth.guard";
 
 @ApiTags("Posts")
 @Controller("posts")
@@ -12,25 +26,37 @@ export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   createPost(@Body() createPostDto: CreatePostDto) {
     return this.postsService.createPost(createPostDto);
   }
 
   @Get()
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiBearerAuth()
   @ApiQuery({ name: "page", required: false, example: 1 })
   @ApiQuery({ name: "limit", required: false, example: 10 })
   @ApiOkResponse({ type: GetPostDto, description: "게시글 목록" })
-  getPosts(@Query("page") page: number, @Query("limit") limit: number) {
+  getPosts(
+    @Query("page") page: number,
+    @Query("limit") limit: number,
+    @Request() req: RequestWithOptionalUser,
+  ) {
+    const userId = req.user?.id;
     if (!page || !limit) {
-      return this.postsService.findAllPosts();
+      return this.postsService.findAllPosts(userId);
     }
-    return this.postsService.findAllPostWithPagination(Number(page), Number(limit));
+    return this.postsService.findAllPostWithPagination(Number(page), Number(limit), userId);
   }
 
   @Get(":id")
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse({ type: PostDetailDto, description: "게시글 상세" })
-  getPostById(@Param("id") id: number) {
-    return this.postsService.findPostById(id);
+  getPostById(@Param("id") id: number, @Request() req: RequestWithOptionalUser) {
+    const userId = req.user?.id;
+    return this.postsService.findPostById(id, userId);
   }
 
   @Patch(":id")

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -28,8 +28,6 @@ export class PostsController {
   @Post()
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  createPost(@Body() createPostDto: CreatePostDto) {
-    return this.postsService.createPost(createPostDto);
   createPost(@Body() createPostDto: CreatePostDto, @Request() req: RequestWithUser) {
     return this.postsService.createPost(createPostDto, req.user);
   }

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -1,5 +1,6 @@
 import { Comment } from "src/post-comments/post-comments.entity";
 import { PostLike } from "src/post-likes/post-likes.entity";
+import { CommentLike } from "src/comment-likes/comment-likes.entity";
 import { Post } from "src/posts/posts.entity";
 import { Entity, Column, PrimaryGeneratedColumn, Index, OneToMany, OneToOne } from "typeorm";
 import { Exclude } from "class-transformer";
@@ -38,4 +39,7 @@ export class User extends BaseTimeEntity {
 
   @OneToMany(() => PostLike, (l) => l.user)
   likes: PostLike[];
+
+  @OneToMany(() => CommentLike, (l) => l.user)
+  commentLikes: CommentLike[];
 }


### PR DESCRIPTION
- 게시글 좋아요 토글 API 추가 (POST /posts/:postId/likes)
- 댓글 좋아요 토글 API 추가 (POST /comments/:commentId/likes)
- 대댓글 1단계까지만 허용 (대댓글의 댓글 작성 불가)
- 게시글/댓글 조회 시 좋아요 정보 포함 (likeCount, isLikedByMe)
- OptionalJwtAuthGuard 추가 (비로그인 사용자도 조회 가능)
- CommentDto에 UserDto 통합 사용
- AuthModule을 필요한 모듈에 import

closes #27 #28 #29 