### PR TITLE
feat: ✨ 게시글 해시태그 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from "./auth/auth.module";
 import { DatabaseSeederModule } from "./database/database-seeder.module";
 import { PostLikesModule } from "./post-likes/post-likes.module";
 import { CommentLikesModule } from "./comment-likes/comment-likes.module";
+import { HashTagModule } from "./hashtag/hash-tag.module";
 import { LoggerMiddleware } from "./common/middleware/logger.middleware";
 
 @Module({
@@ -38,6 +39,7 @@ import { LoggerMiddleware } from "./common/middleware/logger.middleware";
     PostCommentsModule,
     PostLikesModule,
     CommentLikesModule,
+    HashTagModule,
     AuthModule,
     DatabaseSeederModule,
   ],

--- a/src/hashtag/hash-tag.controller.ts
+++ b/src/hashtag/hash-tag.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  HttpCode,
+  HttpStatus,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from "@nestjs/swagger";
+import { HashTagService } from "./hash-tag.service";
+
+@ApiTags("Hashtags")
+@Controller("hashtags")
+export class HashTagController {
+  constructor(private readonly hashTagService: HashTagService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "모든 해시태그 조회" })
+  @ApiResponse({
+    status: 200,
+    description: "해시태그 목록 조회 성공",
+  })
+  async findAllHashtags() {
+    const hashtags = await this.hashTagService.findAllHashtags();
+    return {
+      data: hashtags,
+      total: hashtags.length,
+    };
+  }
+
+  @Get("popular")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "인기 해시태그 조회" })
+  @ApiQuery({
+    name: "limit",
+    required: false,
+    type: Number,
+    description: "조회할 개수",
+    example: 10,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "인기 해시태그 조회 성공",
+  })
+  async findPopularHashtags(@Query("limit", new DefaultValuePipe(10), ParseIntPipe) limit: number) {
+    const hashtags = await this.hashTagService.findPopularHashtags(limit);
+    return {
+      data: hashtags,
+      total: hashtags.length,
+    };
+  }
+
+  @Get(":name/posts")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "해시태그로 게시글 검색" })
+  @ApiParam({ name: "name", description: "해시태그 이름", type: String })
+  @ApiQuery({ name: "page", required: false, type: Number, description: "페이지 번호", example: 1 })
+  @ApiQuery({
+    name: "limit",
+    required: false,
+    type: Number,
+    description: "페이지당 개수",
+    example: 10,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "해시태그로 게시글 검색 성공",
+  })
+  async findPostsByHashtag(
+    @Param("name") hashtagName: string,
+    @Query("page", new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query("limit", new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    return await this.hashTagService.findPostsByHashtag(hashtagName, page, limit);
+  }
+}

--- a/src/hashtag/hash-tag.entity.ts
+++ b/src/hashtag/hash-tag.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToMany,
+  CreateDateColumn,
+  Index,
+} from "typeorm";
+import { Post } from "../posts/posts.entity";
+
+@Entity({ name: "hashtags" })
+@Index(["name"], { unique: true })
+export class HashTag {
+  @PrimaryGeneratedColumn("increment")
+  id: number;
+
+  @Column({ type: "varchar", length: 50, nullable: false, unique: true })
+  name: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  @ManyToMany(() => Post, (post) => post.hashtags)
+  posts: Post[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/hashtag/hash-tag.module.ts
+++ b/src/hashtag/hash-tag.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { HashTag } from "./hash-tag.entity";
+import { Post } from "../posts/posts.entity";
+import { HashTagController } from "./hash-tag.controller";
+import { HashTagService } from "./hash-tag.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([HashTag, Post])],
+  controllers: [HashTagController],
+  providers: [HashTagService],
+  exports: [HashTagService],
+})
+export class HashTagModule {}

--- a/src/hashtag/hash-tag.service.ts
+++ b/src/hashtag/hash-tag.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, In } from "typeorm";
+import { HashTag } from "./hash-tag.entity";
+import { Post } from "../posts/posts.entity";
+
+@Injectable()
+export class HashTagService {
+  constructor(
+    @InjectRepository(HashTag)
+    private readonly hashTagRepository: Repository<HashTag>,
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
+  ) {}
+
+  /**
+   * 해시태그 이름 배열을 받아서 해시태그 엔티티 배열을 반환
+   * 존재하지 않는 해시태그는 새로 생성
+   */
+  async findOrCreateHashtags(hashtagNames: string[]): Promise<HashTag[]> {
+    if (!hashtagNames || hashtagNames.length === 0) {
+      return [];
+    }
+
+    // 해시태그 이름 정규화 (# 제거, 소문자 변환, 공백 제거)
+    const normalizedNames = hashtagNames
+      .map((name) => name.trim().replace(/^#/, "").toLowerCase())
+      .filter((name) => name.length > 0);
+
+    if (normalizedNames.length === 0) {
+      return [];
+    }
+
+    // 기존 해시태그 조회
+    const existingHashtags = await this.hashTagRepository.find({
+      where: { name: In(normalizedNames) },
+    });
+
+    const existingNames = new Set(existingHashtags.map((h) => h.name));
+    const newNames = normalizedNames.filter((name) => !existingNames.has(name));
+
+    // 새로운 해시태그 생성
+    const newHashtags = newNames.map((name) => this.hashTagRepository.create({ name }));
+    if (newHashtags.length > 0) {
+      await this.hashTagRepository.save(newHashtags);
+    }
+
+    return [...existingHashtags, ...newHashtags];
+  }
+
+  /**
+   * 게시글에 해시태그 연결
+   */
+  async attachHashtagsToPost(postId: number, hashtagNames: string[]): Promise<void> {
+    const post = await this.postRepository.findOne({
+      where: { id: postId },
+      relations: ["hashtags"],
+    });
+
+    if (!post) {
+      throw new NotFoundException(`ID ${postId}에 해당하는 게시글을 찾을 수 없습니다.`);
+    }
+
+    const hashtags = await this.findOrCreateHashtags(hashtagNames);
+    post.hashtags = hashtags;
+    await this.postRepository.save(post);
+  }
+
+  /**
+   * 해시태그 이름으로 게시글 검색
+   */
+  async findPostsByHashtag(hashtagName: string, page: number = 1, limit: number = 10) {
+    const normalizedName = hashtagName.trim().replace(/^#/, "").toLowerCase();
+
+    const hashtag = await this.hashTagRepository.findOne({
+      where: { name: normalizedName },
+      relations: ["posts", "posts.user", "posts.likes", "posts.comments"],
+    });
+
+    if (!hashtag) {
+      return {
+        data: [],
+        limit,
+        total: 0,
+        page,
+        totalPages: 0,
+      };
+    }
+
+    const total = hashtag.posts.length;
+    const startIndex = (page - 1) * limit;
+    const endIndex = startIndex + limit;
+    const paginatedPosts = hashtag.posts.slice(startIndex, endIndex);
+
+    return {
+      data: paginatedPosts,
+      limit,
+      total,
+      page,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  /**
+   * 인기 해시태그 조회 (게시글 수가 많은 순서)
+   */
+  async findPopularHashtags(
+    limit: number = 10,
+  ): Promise<Array<Pick<HashTag, "id" | "name" | "createdAt"> & { postCount: number }>> {
+    const hashtags = await this.hashTagRepository
+      .createQueryBuilder("hashtag")
+      .leftJoin("hashtag.posts", "post")
+      .select("hashtag.id", "id")
+      .addSelect("hashtag.name", "name")
+      .addSelect("hashtag.createdAt", "createdAt")
+      .addSelect("COUNT(post.id)", "postCount")
+      .groupBy("hashtag.id")
+      .addGroupBy("hashtag.name")
+      .addGroupBy("hashtag.createdAt")
+      .orderBy("COUNT(post.id)", "DESC")
+      .addOrderBy("hashtag.createdAt", "DESC")
+      .limit(limit)
+      .getRawMany();
+
+    return hashtags.map(
+      (h: { id: number; name: string; createdAt: Date | string; postCount: string }) => ({
+        id: Number(h.id),
+        name: String(h.name),
+        createdAt: h.createdAt instanceof Date ? h.createdAt : new Date(h.createdAt),
+        postCount: parseInt(String(h.postCount), 10) || 0,
+      }),
+    );
+  }
+
+  /**
+   * 모든 해시태그 조회
+   */
+  async findAllHashtags(): Promise<HashTag[]> {
+    return await this.hashTagRepository.find({
+      order: { createdAt: "DESC" },
+    });
+  }
+}

--- a/src/posts/dto/createPost.dto.ts
+++ b/src/posts/dto/createPost.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional } from "class-validator";
+import { IsOptional, IsArray, IsString } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 import { IsNotBlank } from "../../common/validators";
 
@@ -11,4 +11,14 @@ export class CreatePostDto {
   @ApiProperty({ example: "게시글 내용" })
   @IsNotBlank()
   content: string;
+
+  @ApiProperty({
+    example: ["태그1", "태그2", "태그3"],
+    description: "해시태그 배열",
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  hashtags?: string[];
 }

--- a/src/posts/dto/postDetail.dto.ts
+++ b/src/posts/dto/postDetail.dto.ts
@@ -40,4 +40,8 @@ export class PostDetailDto {
   @ApiProperty({ type: [CommentDto] })
   @Expose()
   comments: CommentDto[];
+
+  @ApiProperty({ example: ["태그1", "태그2"], description: "해시태그 배열", type: [String] })
+  @Expose()
+  hashtags?: string[];
 }

--- a/src/posts/dto/postList.dto.ts
+++ b/src/posts/dto/postList.dto.ts
@@ -39,4 +39,8 @@ export class PostListDto {
   @ApiProperty({ example: false, description: "내가 좋아요를 눌렀는지 여부 (로그인 시에만)" })
   @Expose()
   isLikedByMe: boolean;
+
+  @ApiProperty({ example: ["태그1", "태그2"], description: "해시태그 배열", type: [String] })
+  @Expose()
+  hashtags?: string[];
 }

--- a/src/posts/dto/updatePost.dto.ts
+++ b/src/posts/dto/updatePost.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional } from "class-validator";
+import { IsOptional, IsArray, IsString } from "class-validator";
 import { IsNotBlank } from "src/common/validators";
 import { ApiProperty } from "@nestjs/swagger";
 
@@ -11,4 +11,14 @@ export class UpdatePostDto {
   @ApiProperty({ example: "게시글 내용" })
   @IsNotBlank()
   content?: string;
+
+  @ApiProperty({
+    example: ["태그1", "태그2", "태그3"],
+    description: "해시태그 배열",
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  hashtags?: string[];
 }

--- a/src/posts/posts.entity.ts
+++ b/src/posts/posts.entity.ts
@@ -6,10 +6,13 @@ import {
   UpdateDateColumn,
   ManyToOne,
   OneToMany,
+  ManyToMany,
+  JoinTable,
 } from "typeorm";
 import { User } from "../users/users.entity";
 import { Comment } from "../post-comments/post-comments.entity";
 import { PostLike } from "../post-likes/post-likes.entity";
+import { HashTag } from "../hashtag/hash-tag.entity";
 import { ApiProperty } from "@nestjs/swagger";
 
 @Entity({ name: "posts" })
@@ -43,4 +46,12 @@ export class Post {
 
   @OneToMany(() => PostLike, (l) => l.post, { cascade: true })
   likes: PostLike[];
+
+  @ManyToMany(() => HashTag, (hashtag) => hashtag.posts)
+  @JoinTable({
+    name: "post_hashtags",
+    joinColumn: { name: "post_id", referencedColumnName: "id" },
+    inverseJoinColumn: { name: "hashtag_id", referencedColumnName: "id" },
+  })
+  hashtags: HashTag[];
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -4,9 +4,10 @@ import { PostsController } from "./posts.controller";
 import { PostsService } from "./posts.service";
 import { Post } from "./posts.entity";
 import { User } from "../users/users.entity";
+import { HashTagModule } from "../hashtag/hash-tag.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, User])],
+  imports: [TypeOrmModule.forFeature([Post, User]), HashTagModule],
   controllers: [PostsController],
   providers: [PostsService],
   exports: [PostsService],

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException, ForbiddenException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, UpdateResult } from "typeorm";
+import { Repository } from "typeorm";
 import { Post } from "./posts.entity";
 import { CreatePostDto } from "./dto/createPost.dto";
 import { UpdatePostDto } from "./dto/updatePost.dto";
@@ -11,6 +11,7 @@ import { PostDetailDto } from "./dto/postDetail.dto";
 import { User } from "../users/users.entity";
 import { CommentDto } from "../post-comments/dto/comment.dto";
 import { JwtPayload } from "../auth/dto/jwtPayload.dto";
+import { HashTagService } from "../hashtag/hash-tag.service";
 
 @Injectable()
 export class PostsService {
@@ -19,22 +20,42 @@ export class PostsService {
     private readonly postRepository: Repository<Post>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    private readonly hashTagService: HashTagService,
   ) {}
 
   async createPost(createPostDto: CreatePostDto, user: JwtPayload): Promise<Post> {
+    // 해시태그 분리
+    const { hashtags, ...postData } = createPostDto;
+
     // JWT 토큰에서 가져온 user 정보로 게시글 생성
     const entity = this.postRepository.create({
       user: { id: user.id },
-      ...createPostDto,
+      ...postData,
     });
-    return await this.postRepository.save(entity);
+    const savedPost = await this.postRepository.save(entity);
+
+    // 해시태그 연결
+    if (hashtags && hashtags.length > 0) {
+      await this.hashTagService.attachHashtagsToPost(savedPost.id, hashtags);
+    }
+
+    // 해시태그를 포함한 게시글 반환
+    const foundPost = await this.postRepository.findOne({
+      where: { id: savedPost.id },
+      relations: ["hashtags", "user"],
+    });
+
+    if (!foundPost) {
+      throw new NotFoundException(`ID ${savedPost.id}에 해당하는 게시글을 찾을 수 없습니다.`);
+    }
+    return foundPost;
   }
 
   // 전체 목록
   async findAllPosts(userId?: number): Promise<GetPostDto> {
     const result = await this.postRepository.find({
       order: { createdAt: "DESC" },
-      relations: ["comments", "likes", "likes.user", "user"],
+      relations: ["comments", "likes", "likes.user", "user", "hashtags"],
     });
 
     const data = result.map((post) => ({
@@ -42,6 +63,7 @@ export class PostsService {
       likeCount: post.likes.length || 0,
       commentsCount: post.comments.length || 0,
       isLikedByMe: userId ? post.likes.some((like) => like.user.id === userId) : false,
+      hashtags: post.hashtags?.map((h) => h.name) || [],
     }));
 
     return {
@@ -63,7 +85,7 @@ export class PostsService {
       skip: (page - 1) * limit,
       take: limit,
       order: { createdAt: "DESC" },
-      relations: ["comments", "likes", "likes.user", "user"],
+      relations: ["comments", "likes", "likes.user", "user", "hashtags"],
     });
 
     const data = result.map((post) => ({
@@ -71,6 +93,7 @@ export class PostsService {
       likeCount: post.likes.length || 0,
       commentsCount: post.comments.length || 0,
       isLikedByMe: userId ? post.likes.some((like) => like.user.id === userId) : false,
+      hashtags: post.hashtags?.map((h) => h.name) || [],
     }));
 
     return {
@@ -89,6 +112,7 @@ export class PostsService {
         "user",
         "likes",
         "likes.user",
+        "hashtags",
         "comments",
         "comments.user",
         "comments.likes",
@@ -112,6 +136,7 @@ export class PostsService {
     const postData = plainToInstance(PostDetailDto, post, { excludeExtraneousValues: true });
     postData.likeCount = post.likes?.length || 0;
     postData.isLikedByMe = userId ? post.likes.some((like) => like.user.id === userId) : false;
+    postData.hashtags = post.hashtags?.map((h) => h.name) || [];
 
     // 댓글 데이터 매핑 (부모 댓글만 필터링)
     const parentComments = post.comments.filter((comment) => !comment.parentComment);
@@ -141,11 +166,11 @@ export class PostsService {
     return postData;
   }
 
-  async updatePost(id: number, dto: UpdatePostDto, user: JwtPayload): Promise<UpdateResult> {
+  async updatePost(id: number, dto: UpdatePostDto, user: JwtPayload): Promise<Post> {
     // 게시글 존재 여부 및 작성자 확인
     const post = await this.postRepository.findOne({
       where: { id },
-      relations: ["user"],
+      relations: ["user", "hashtags"],
     });
 
     if (!post) {
@@ -157,7 +182,28 @@ export class PostsService {
       throw new ForbiddenException("본인의 게시글만 수정할 수 있습니다.");
     }
 
-    return await this.postRepository.update(id, dto);
+    // 해시태그 분리
+    const { hashtags, ...postData } = dto;
+
+    // 게시글 내용 업데이트
+    if (Object.keys(postData).length > 0) {
+      await this.postRepository.update(id, postData);
+    }
+
+    // 해시태그 업데이트
+    if (hashtags) {
+      await this.hashTagService.attachHashtagsToPost(id, hashtags);
+    }
+
+    // 업데이트된 게시글 반환
+    const updatedPost = await this.postRepository.findOne({
+      where: { id },
+      relations: ["hashtags", "user"],
+    });
+    if (!updatedPost) {
+      throw new NotFoundException(`ID ${id}에 해당하는 게시글을 찾을 수 없습니다.`);
+    }
+    return updatedPost;
   }
 
   async deletePost(id: number, user: JwtPayload): Promise<void> {


### PR DESCRIPTION
- Post와 HashTag 간 many-to-many 관계 설정
- 해시태그 엔티티 및 서비스 구현
  - 해시태그 자동 생성 및 정규화 (# 제거, 소문자 변환)
  - 게시글에 해시태그 연결 기능
  - 해시태그로 게시글 검색 기능
  - 인기 해시태그 조회 기능 (게시글 수 기준)
- 게시글 생성/수정 시 해시태그 처리 추가
- 해시태그 API 엔드포인트 구현
  - GET /hashtags: 모든 해시태그 조회
  - GET /hashtags/popular: 인기 해시태그 조회
  - GET /hashtags/:name/posts: 해시태그로 게시글 검색
- 게시글 DTO에 해시태그 필드 추가 (CreatePostDto, UpdatePostDto, PostListDto, PostDetailDto)

closes #23 